### PR TITLE
doc: add method to generate datasets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ After that, you can use `scripts/train.py` to train the diffusion model.
   # run rollout
   # if (self.epoch % cfg.training.rollout_every) == 0:
   ```
+- There are **ghost values** in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`, such as `num_envs`, which should be considered.
 
 ## Training
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ source env.sh
 python ./scripts/eval.py --checkpoint=./cyberdog_final.ckpt --task=cyber2_walk
 ```
 
+## Dataset Generation
+
+To generate the dataset from source RL checkpoints for each task, run the following command:
+
+```bash
+source env.sh
+
+python ./scripts/eval.py --checkpoint=./cyberdog_final.ckpt --task=<TASK_NAME>
+--online=false --generate_dataset=true
+```
+
+Then, use `scripts/combine_dataset.py` to combine the generated datasets (`skill_filenames` should be modified).
+
+After that, you can use `scripts/train.py` to train the diffusion model.
+
 ## Training
 
 ```bash
@@ -123,7 +138,6 @@ source env.sh
 
 python scripts/train.py
 ```
-Currently dataset generation is still pending. 
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ source env.sh
 python ./scripts/eval.py --checkpoint=./cyberdog_final.ckpt --task=cyber2_walk
 ```
 
-## Dataset Generation
+## Dataset Generation (Inofficial Guide)
 
 To generate the dataset from source RL checkpoints for each task, run the following command:
 
@@ -135,6 +135,7 @@ After that, you can use `scripts/train.py` to train the diffusion model.
 - Looks like only `cyber2_stand.pt` source RL policy available for now.
 - Names of datasets should be adapted in `scripts/combine_dataset.py` and `diffusion_policy/config_files/cyber_diffusion_policy_medium_model.yaml`.
 - Change the record length by editing var `len_to_save` in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
+- Condition dims are not match in the original codes, therefore set it to `cond_dim: 45` in `cyber_diffusion_policy_medium_model.yaml` 
 
 ## Training
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,12 @@ After that, you can use `scripts/train.py` to train the diffusion model.
 - Looks like only `cyber2_stand.pt` source RL policy available for now.
 - Names of datasets should be adapted in `scripts/combine_dataset.py` and `diffusion_policy/config_files/cyber_diffusion_policy_medium_model.yaml`.
 - Change the record length by editing var `len_to_save` in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
-- Condition dims are not match in the original codes, therefore set it to `cond_dim: 45` in `cyber_diffusion_policy_medium_model.yaml` 
+- Condition dims are not match in the original codes, therefore set it to `cond_dim: 45` in `cyber_diffusion_policy_medium_model.yaml`
+- Comment out this to avoid infinity rolling out in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
+  ```
+  # run rollout
+  # if (self.epoch % cfg.training.rollout_every) == 0:
+  ```
 
 ## Training
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Then, use `scripts/combine_dataset.py` to combine the generated datasets (`skill
 
 After that, you can use `scripts/train.py` to train the diffusion model.
 
+**NOTE**:
+- Looks like only `cyber2_stand.pt` source RL policy available for now.
+- Names of datasets should be adapted in `scripts/combine_dataset.py` and `diffusion_policy/config_files/cyber_diffusion_policy_medium_model.yaml`.
+- Change the record length by editing var `len_to_save` in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
+
 ## Training
 
 ```bash


### PR DESCRIPTION
The dataset generation is not described in README, therefore I added it here:

## Dataset Generation (Inofficial Guide)

To generate the dataset from source RL checkpoints for each task, run the following command:

```bash
source env.sh

python ./scripts/eval.py --checkpoint=./cyberdog_final.ckpt --task=<TASK_NAME>
--online=false --generate_dataset=true
```

Then, use `scripts/combine_dataset.py` to combine the generated datasets (`skill_filenames` should be modified).

After that, you can use `scripts/train.py` to train the diffusion model.

**NOTE**:
- Looks like only `cyber2_stand.pt` source RL policy available for now.
- Names of datasets should be adapted in `scripts/combine_dataset.py` and `diffusion_policy/config_files/cyber_diffusion_policy_medium_model.yaml`.
- Change the record length by editing var `len_to_save` in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
- Condition dims are not match in the original codes, therefore set it to `cond_dim: 45` in `cyber_diffusion_policy_medium_model.yaml`
- Comment out this to avoid infinity rolling out in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`
  ```
  # run rollout
  # if (self.epoch % cfg.training.rollout_every) == 0:
  ```
- There are **ghost values** in `diffusion_policy/diffusion_policy/env_runner/cyber_runner.py`, such as `num_envs`, which should be considered.